### PR TITLE
Improve Windows-friendliness for MSVC builds.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,10 +84,15 @@ ifeq (,$(OS))
     endif
 else
     ifeq (Windows_NT,$(OS))
-        ifeq ($(findstring WOW64, $(shell uname)),WOW64)
+        SHELL=cmd.exe
+        ifeq ($(findstring AMD64,$(shell echo %PROCESSOR_ARCHITECTURE%)),AMD64)
             OS:=win64
         else
-            OS:=win32
+            ifeq ($(findstring AMD64,$(shell echo %PROCESSOR_ARCHITEW6432%)),AMD64)
+                OS:=win64
+            else
+                OS:=win32
+            endif
         endif
     endif
     ifeq (Win_32,$(OS))
@@ -110,6 +115,7 @@ export MODEL=32
 export REQUIRED_ARGS=
 
 ifeq ($(findstring win,$(OS)),win)
+SHELL=bash.exe
 export ARGS=-inline -release -g -O -unittest
 export DMD=../src/dmd.exe
 export EXE=.exe
@@ -120,7 +126,6 @@ export SEP=$(subst /,\,/)
 DRUNTIME_PATH=..\..\druntime
 PHOBOS_PATH=..\..\phobos
 export DFLAGS=-I$(DRUNTIME_PATH)\import -I$(PHOBOS_PATH)
-export LIB=$(PHOBOS_PATH)
 else
 export ARGS=-inline -release -gc -O -unittest -fPIC
 export DMD=../src/dmd

--- a/d_do_test.d
+++ b/d_do_test.d
@@ -436,6 +436,9 @@ int main(string[] args)
     string output_file    = result_path ~ input_dir ~ envData.sep ~ test_name ~ "." ~ test_extension ~ ".out";
     string test_app_dmd_base = output_dir ~ envData.sep ~ test_name ~ "_";
 
+    if (envData.all_args == envData.sep)
+        envData.all_args = "";
+
     TestArgs testArgs;
 
     switch (input_dir)

--- a/d_do_test.d
+++ b/d_do_test.d
@@ -453,7 +453,7 @@ int main(string[] args)
         switch (envData.os)
         {
             case "win32": envData.ccompiler = "dmc"; break;
-            case "win64": envData.ccompiler = `\"Program Files (x86)"\"Microsoft Visual Studio 10.0"\VC\bin\amd64\cl.exe`; break;
+            case "win64": envData.ccompiler = "cl.exe"; break;
             default:      envData.ccompiler = "g++"; break;
         }
     }

--- a/runnable/test22.d
+++ b/runnable/test22.d
@@ -237,8 +237,9 @@ void assertEqual(real* a, real* b, string file = __FILE__, size_t line = __LINE_
 
     // Only compare the 10 value bytes, the padding bytes are of undefined
     // value.
-    version (X86) enum count = 10;
-    else version (X86_64) enum count = 10;
+    import std.algorithm.comparison: min;
+    version (X86) enum count = min(real.sizeof, 10);
+    else version (X86_64) enum count = min(real.sizeof, 10);
     else enum count = real.sizeof;
     for (size_t i = 0; i < count; i++)
     {


### PR DESCRIPTION
The only essential dependencies are GNU `make` for Windows and `bash` with some tools (`diff`, `grep`...). `bash` and GNU tools are included by `git` for Windows distributions.

This commit fixes the x64/x86 detection (my Win8 x64 was detected as `OS=win32` due to `uname.exe` provided by git returning `MINGW32_NT-6.2`), doesn't overwrite the `LIB` environment variable (which is crucial for the MS linker) and assumes `cl.exe` to be in a directory in the `PATH` environment variable rather than a hardcoded path to VS 2010.

A binary distribution of GNU `make` for Windows (v3.81 from 2006) is available at http://gnuwin32.sourceforge.net/packages/make.htm - you'll need the binaries and dependencies ZIPs.
Some scripts require GNU `diff` to support `--strip-trailing-cr`, which wasn't the case for the ancient `diff.exe` (v2.7) provided by my git distribution. A newer version (2.8.7) can be downloaded from http://gnuwin32.sourceforge.net/packages/diffutils.htm.