### PR TITLE
Disable runnable/ldc_extern_weak for OS X.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,6 +224,11 @@ DISABLED_TESTS += testclass
 # LDC: Test specific to DMD's library names.
 DISABLED_SH_TESTS += test_shared
 
+# LDC: OS X ld needs extra options, but not needed so do not bother
+ifeq ($(OS),osx)
+DISABLED_TESTS += ldc_extern_weak
+endif
+
 ####
 
 ifeq ($(OS),win64)

--- a/runnable/ldc_extern_weak.d
+++ b/runnable/ldc_extern_weak.d
@@ -9,3 +9,7 @@ void main() {
     // to 'true' for weak symbols.
     assert(!doesNonExistentExist());
 }
+
+// OS X note: ld complains extern_weak symbols are undefined unless ld options
+// -undefined dynamic_lookup or -U __D15ldc_extern_weak11nonExistenti are
+// provided.  extern_weak not really needed on OS X though.


### PR DESCRIPTION
Refresh and retarget of #8.

Could work if linker given option -undefined dynamic_lookup, but the feature is not needed on OS X.