### PR TITLE
Fix NO_ARCH_VARIANT setting in Makefile for ARM, AArch64 (and ldc_github_1292 too)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,7 +239,8 @@ ifeq ($(OS),linux)
 
   # disable invalid tests on arm, aarch64
   ifneq (,$(filter arm% aarch64%,$(ARCH)))
-    export NO_ARCH_VARIANT=1	# tell d_do_test.d to ignore MODEL
+    # tell d_do_test.d to ignore MODEL
+    export NO_ARCH_VARIANT=1
 
     DISABLED_COMPILE_TESTS += deprecate12979a # dmd inline asm
     DISABLED_COMPILE_TESTS += ldc_github_791  # dmd inline asm

--- a/Makefile
+++ b/Makefile
@@ -244,6 +244,7 @@ ifeq ($(OS),linux)
 
     DISABLED_COMPILE_TESTS += deprecate12979a # dmd inline asm
     DISABLED_COMPILE_TESTS += ldc_github_791  # dmd inline asm
+    DISABLED_COMPILE_TESTS += ldc_github_1292 # dmd inline asm
     DISABLED_COMPILE_TESTS += test11471       # dmd inline asm
     DISABLED_COMPILE_TESTS += test12979b      # dmd inline asm
     DISABLED_FAIL_TESTS += deprecate12979a    # dmd inline asm


### PR DESCRIPTION
Environment var NO_ARCH_VARIANT to disable -m32/-m64 wasn't working after I added a trailing comment.  Turns out make includes all whitespace up to a comment, so NO_ARCH_VARIANT=1 was being set to "1\t".
