### PR TITLE
Bypass test42.test103 for ARM, AArch64

### DIFF
--- a/runnable/test42.d
+++ b/runnable/test42.d
@@ -1674,11 +1674,6 @@ void test101()
 /***************************************************/
 
 version(X86)
-    version = Test103;
-else version(ARM)
-    version = Test103;
-
-version(Test103)
 {
 int x103;
 
@@ -1713,6 +1708,14 @@ void test103()
 else version(X86_64)
 {
     pragma(msg, "Not ported to x86-64 compatible varargs, yet.");
+    void test103() {}
+}
+else version(AArch64)
+{
+    void test103() {}
+}
+else version(ARM)
+{
     void test103() {}
 }
 else


### PR DESCRIPTION
This is one way of getting runnable/test42 to pass post ldc-developers/ldc#1346.
`test103()` expects `va_list` to be a pointer type, but it isn't for ARM AAPCS and AArch64 AAPCS64.

I'm not sure what `test103()` is testing though.  Is it testing pointer-ness of `_argptr` in which case there is no porting, or is it testing vararg mechanics and should be updated to use va_arg calls?

@braddr - I think you were original author long ago.  Thoughts?