### PR TITLE
Disable test16225 for ARM and others w/o -m64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -255,12 +255,16 @@ ifeq ($(OS),linux)
   ARCH:=$(shell uname -m)
 
   # disable invalid tests on arm, aarch64, mips, ppc
+  # note: as of llvm-3.8.0, arm/thumb and aarch64 are considered
+  # -m32/-m64 variants and the 'no -m64' tests below can be enabled
+  # when older llvm is not supported.
   ifneq (,$(filter arm% aarch64% mips% ppc%,$(ARCH)))
     DISABLED_COMPILE_TESTS += deprecate12979a # dmd inline asm
     DISABLED_COMPILE_TESTS += ldc_github_791  # dmd inline asm
     DISABLED_COMPILE_TESTS += ldc_github_1292 # dmd inline asm
     DISABLED_COMPILE_TESTS += test11471       # dmd inline asm
     DISABLED_COMPILE_TESTS += test12979b      # dmd inline asm
+    DISABLED_COMPILE_TESTS += test16225       # no -m64
     DISABLED_FAIL_TESTS += deprecate12979a    # dmd inline asm
     DISABLED_FAIL_TESTS += deprecate12979b    # dmd inline asm
     DISABLED_FAIL_TESTS += deprecate12979c    # dmd inline asm


### PR DESCRIPTION
test16225 requires -m64 which is not supported when using llvm < 3.8.0 on ARM.
