### PR TITLE
[ltsmaster] Disable test requiring -m32 for ppc64le.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,6 +264,19 @@ ifeq ($(OS),linux)
     DISABLED_TESTS += test36                  # dmd inline asm/Windows
   endif
 
+  ifneq (,$(filter ppc64le%,$(ARCH)))
+    DISABLED_COMPILE_TESTS += ddoc10367       # no -m32
+    DISABLED_COMPILE_TESTS += ddoc2273        # no -m32
+    DISABLED_FAIL_TESTS += diag12480          # no -m32
+    DISABLED_FAIL_TESTS += diag7420           # no -m32
+    DISABLED_FAIL_TESTS += diag9250           # no -m32
+    DISABLED_FAIL_TESTS += diag9635           # no -m32
+    DISABLED_FAIL_TESTS += fail13434_m32      # no -m32
+    DISABLED_FAIL_TESTS += fail238_m32        # no -m32
+    DISABLED_FAIL_TESTS += fail37_m32         # no -m32
+    DISABLED_FAIL_TESTS += fail80_m32         # no -m32
+  endif
+
   ifneq (,$(filter arm% aarch64% ppc64le%,$(ARCH)))
     # tell d_do_test.d to ignore MODEL
     export NO_ARCH_VARIANT=1


### PR DESCRIPTION
ppc64le is a pure 64bit platform - there is no 32bit hardware.

This PR fixes all failing compilable and fail tests for ppc64le.